### PR TITLE
Potential bug fix with prop updates not rerendering with new data

### DIFF
--- a/vars.js
+++ b/vars.js
@@ -33,16 +33,16 @@ module.exports = {
         chart.destroy();
       };
 
-      classData.componentWillReceiveProps = function(props) {
+      classData.componentWillReceiveProps = function(nextProps) {
         var chart = this.state.chart;
         chart.destroy();
-        this.initializeChart(props);
+        this.initializeChart(nextProps);
       };
 
-      classData.initializeChart = function(props) {
+      classData.initializeChart = function(nextProps) {
         var el = this.getDOMNode();
         var ctx = el.getContext("2d");
-        var chart = new Chart(ctx)[chartType](this.props.data, this.props.options || {});
+        var chart = new Chart(ctx)[chartType](nextProps.data, nextProps.options || {});
         this.state.chart = chart;
       };
 


### PR DESCRIPTION
Hi, this is a nifty module! Thanks for sharing.

I was trying to re-render my line chart by changing values in the parent component, so that the LineChart would recognize a prop update, but I discovered that it wouldn't re-render the chart using the new values. If I tried updating its props a second time, it would use the values from the first update.

I think initializeChart should use the props/nextProps argument instead of this.props because this.props gets gets updated after componentWillReceiveProps finishes. Let me know what you think.
