### PR TITLE
Allow custom chart types.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,5 +4,6 @@ module.exports = {
   Line: require('./lib/line'),
   Pie: require('./lib/pie'),
   PolarArea: require('./lib/polar-area'),
-  Radar: require('./lib/radar')
+  Radar: require('./lib/radar'),
+  createClass: require('./lib/core').createClass
 };

--- a/lib/core.js
+++ b/lib/core.js
@@ -1,5 +1,5 @@
 module.exports = {
-  createClass: function(chartType, methodNames) {
+  createClass: function(chartType, methodNames, dataKey) {
     var classData = {
       displayName: chartType + 'Chart',
       getInitialState: function() { return {}; },
@@ -40,7 +40,8 @@ module.exports = {
         chart.destroy();
         this.initializeChart(nextProps);
       } else {
-        updatePoints(nextProps, chart);
+        dataKey = dataKey || dataKeys[chart.name];
+        updatePoints(nextProps, chart, dataKey);
         chart.update();
       }
     };
@@ -82,7 +83,7 @@ var dataKeys = {
   'Bar': 'bars'
 };
 
-var updatePoints = function(nextProps, chart) {
+var updatePoints = function(nextProps, chart, dataKey) {
   var name = chart.name;
 
   if (name === 'PolarArea' || name === 'Pie' || name === 'Doughnut') {
@@ -90,7 +91,6 @@ var updatePoints = function(nextProps, chart) {
       chart.segments[segmentIndex].value = segment.value;
     });
   } else {
-    var dataKey = dataKeys[name];
     nextProps.data.datasets.forEach(function(set, setIndex) {
       set.data.forEach(function(val, pointIndex) {
         chart.datasets[setIndex][dataKey][pointIndex].value = val;


### PR DESCRIPTION
This changeset exposes the `createClass` method in `lib/core`, and adds a third argument to it so that you can pass the `dataKey` value that was previously fixed in the `dataKeys` variable.

E. g. if you want to use https://github.com/Regaddi/Chart.StackedBar.js, you would do something like `var StackedBarChart = require('react-chartjs').createClass('StackedBar', ['getBarsAtEvent'], 'bars');` (provided you previously registered `StackedBar` with Chart.js, of course).
