### PR TITLE
alias getCanvas to existing getCanvass function

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -66,6 +66,8 @@ module.exports = {
       return this.refs.canvass.getDOMNode();
     };
 
+    classData.getCanvas = classData.getCanvass;
+
     var i;
     for (i=0; i<extras.length; i++) {
       extra(extras[i]);


### PR DESCRIPTION
@jhudson8 readme (#18) refers to getCanvas, but the actual function is called getCanvass, this aliases getCanvas to getCanvass so existing integrations don't break but correct spelling can be used going forward.
