### PR TITLE
Fix to work with HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,11 +9,11 @@
       }
     </style>
 
-    <script src="http://fb.me/react-0.13.1.min.js"></script>
+    <script src="https://fb.me/react-0.13.1.min.js"></script>
     <script type="text/javascript" src="./showcase-chart.js"></script>
     <script type="text/javascript" src="./react-chartjs.js"></script>
-    <script type="text/javascript" src="http://underscorejs.org/underscore.js"></script>
-    <script type="text/javascript" src="http://zeptojs.com/zepto.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/zepto/1.1.6/zepto.min.js"></script>
   </head>
   <body>
 <pre><code>
@@ -209,4 +209,3 @@ Chart.defaults.global.responsive = true;
 
   </script>
 </html>
-    


### PR DESCRIPTION
Explicitly specifying http to load libs from the CDN causes failures on modern browsers if the HTML page was loaded via https (e.g., this can happen if using the [HTTPS Everywhere](https://www.eff.org/https-everywhere) extension). 

This also switches out the CDNs for zepto and underscore primarily because it doesn't seem like zepto uses HTTPS.
