### PR TITLE
Copy across the specified properties of each dataset when updating the chart

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -59,9 +59,17 @@ module.exports = {
       chart.data.labels = [];
 
       // Adds the datapoints from nextProps
+      var propsToCopy = ['hidden'];
+
       nextProps.data.datasets.forEach(function(set, setIndex) {
         set.data.forEach(function(val, pointIndex) {
           chart.data.datasets[setIndex].data[pointIndex] = nextProps.data.datasets[setIndex].data[pointIndex];
+        });
+
+        propsToCopy.forEach(function(prop) {
+            if (nextProps.data.datasets[setIndex][prop] !== undefined) {
+                chart.data.datasets[setIndex][prop] = nextProps.data.datasets[setIndex][prop];
+            }
         });
       });
 


### PR DESCRIPTION
I noticed that no properties of the datasets are copied across when updating the chart from a `props` change - in my case, trying to show or hide a series with a checkbox.

I'm open for discussion on the best way to do this - for now I've just created a whilelist of properties to copy across (with just my use case in it :)) but maybe there is a better way... could the entire `datasets` property just be copied across? I wasn't sure what the reasoning behind iterating over it and copying across one by one is.
