### PR TITLE
fix chart.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "react": "*",
     "react-dom": "*",
-    "chart.js": "*"
+    "chart.js": "^1.0.2"
   },
   "devDependencies": {
     "uglify-js": "^2.4.16",


### PR DESCRIPTION
chart.js interface changed from 2.0.0 later.

for example:

``` js
// version 1.0.2
var myBarChart = new Chart(ctx)["Bar"](data, options);
// version 2.0.0 later.
var myBarChart = new Chart(ctx, {type: "bar", data: data, options: options});
```

now `npm install Chart.js --save` installed 2.0.0 by default.
cannot executable [this line](https://github.com/jhudson8/react-chartjs/blob/master/lib/core.js#L63)

more detail [1.x](http://www.chartjs.org/docs/) [2.x](http://nnnick.github.io/Chart.js/docs-v2/)
