### PR TITLE
enable line chart to change it colors dynamically

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -47,7 +47,7 @@ module.exports = {
         updatePoints(nextProps, chart, dataKey);
         if (chart.scale) {
           chart.scale.xLabels = nextProps.data.labels;
-           
+
             if (chart.scale.calculateXLabelRotation){
           chart.scale.calculateXLabelRotation();
             }
@@ -127,11 +127,24 @@ var updatePoints = function(nextProps, chart, dataKey) {
       chart.removeData();
     }
     nextProps.data.datasets.forEach(function(set, setIndex) {
+      // updating properties
+      Object.keys(set).forEach(function (prop) {
+        var val = set[prop];
+        if (prop === 'data') return; // skip data
+        chart.datasets[setIndex][prop] = val;
+      });
+
+      // updating points
       set.data.forEach(function(val, pointIndex) {
         if (typeof(chart.datasets[setIndex][dataKey][pointIndex]) == "undefined") {
           addData(nextProps, chart, setIndex, pointIndex);
         } else {
           chart.datasets[setIndex][dataKey][pointIndex].value = val;
+          // update point color if available
+          if (set.pointColor) {
+            chart.datasets[setIndex][dataKey][pointIndex].fillColor = set.pointColor;
+            chart.datasets[setIndex][dataKey][pointIndex].highlightFill = set.pointColor;
+          }
         }
       });
     });


### PR DESCRIPTION
Hey,

we recently introduced this lib into our own app and i noticed that one cannot change the line chart color dynamically. Looking at the code shows that only datapoints are updated, but updating other properties from the dataset can also be updated (i tested that locally).

So here the PR, this enables the Line Chart to update it's colors dynamically without setting the `redraw` attribute.
