### PR TITLE
Force chart.js version - otherwise chart.js 2 is getting installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "react": "*",
     "react-dom": "*",
-    "chart.js": "*"
+    "chart.js": "^1.1.1"
   },
   "devDependencies": {
     "uglify-js": "^2.4.16",


### PR DESCRIPTION
chart.js 2 beta is released on npm, so when i install react-chartjs,  chart.js v2 is getting installed as peer dependency. force it to v1.
