### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "react": "*",
     "react-dom": "*",
-    "chart.js": "*"
+    "chart.js": "^1.x"
   },
   "devDependencies": {
     "uglify-js": "^2.4.16",


### PR DESCRIPTION
chart.js 2.0 is released. Current version will break with "[chartType] is not a function" error.
