### PR TITLE
Chartjs version instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ This is a CommonJS component only (to be used with something like Webpack or Bro
 ```
 npm install --save react-chartjs
 ```
-You must also include [chart.js](https://www.npmjs.com/package/chart.js) and [React](https://www.npmjs.com/package/react) as dependencies.
+You must also include [chart.js](https://www.npmjs.com/package/chart.js) and [React](https://www.npmjs.com/package/react) as dependencies.  
+```
+npm i chart.js@^1.1.1 react react-dom --save
+```  
 
 Example Usage
 -------------

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm install --save react-chartjs
 ```
 You must also include [chart.js](https://www.npmjs.com/package/chart.js) and [React](https://www.npmjs.com/package/react) as dependencies.  
 ```
-npm i chart.js@^1.1.1 react react-dom --save
+npm install --save chart.js@^1.1.1 react react-dom
 ```  
 
 Example Usage


### PR DESCRIPTION
- Currently it works with ChartJS v1 and we should denote it so it's clear for people how to install
