### PR TITLE
Include HorizontalBar as an available type

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ rich interactive react charting components using [chart.js](http://www.chartjs.o
 
 * Line chart
 * Bar chart
+* HorizontalBar chart
 * Radar chart
 * Polar area chart
 * Pie chart

--- a/lib/core.js
+++ b/lib/core.js
@@ -73,7 +73,12 @@ module.exports = {
     classData.initializeChart = function(nextProps) {
       var el = ReactDOM.findDOMNode(this);
       var ctx = el.getContext("2d");
-      var type = (chartType === 'PolarArea') ? 'polarArea':chartType.toLowerCase();
+      let convertToType = function(string){
+        if(string === 'PolarArea') { return 'polarArea' }
+        if(string === 'HorizontalBar') { return 'horizontalBar' }
+        return string.toLowerCase();
+      }
+      var type = convertToType(chartType);
 
       this.state.chart = new Chart(ctx, {
         type: type,

--- a/lib/core.js
+++ b/lib/core.js
@@ -73,11 +73,11 @@ module.exports = {
     classData.initializeChart = function(nextProps) {
       var el = ReactDOM.findDOMNode(this);
       var ctx = el.getContext("2d");
-      let convertToType = function(string){
-        if(string === 'PolarArea') { return 'polarArea' }
-        if(string === 'HorizontalBar') { return 'horizontalBar' }
+      var convertToType = function(string) {
+        if(string === 'PolarArea') { return 'polarArea'; }
+        if(string === 'HorizontalBar') { return 'horizontalBar'; }
         return string.toLowerCase();
-      }
+      };
       var type = convertToType(chartType);
 
       this.state.chart = new Chart(ctx, {

--- a/lib/horizontal-bar.js
+++ b/lib/horizontal-bar.js
@@ -1,0 +1,3 @@
+var vars = require('./core');
+
+module.exports = vars.createClass('HorizontalBar', ['getHorizontalBarsAtEvent']);


### PR DESCRIPTION
This adds `horizontalBar` as an available type of chart.

There is a small refactor to the way the `type` passed into chart.js to account for more that can be covered by a simple ternary assignment.
