### PR TITLE
new feature support: stream chart

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -44,7 +44,7 @@ module.exports = {
         chart.destroy();
         this.initializeChart(nextProps);
       } else if (nextProps.stream) {
-        chart.addData(nextProps.nextPoints.values, nextProps.nextPoints.label);
+        chart.addData(nextProps.data.nextPoints.values, nextProps.data.nextPoints.label);
         chart.removeData();
       } else {
         dataKey = dataKey || dataKeys[chart.name];

--- a/lib/core.js
+++ b/lib/core.js
@@ -43,7 +43,7 @@ module.exports = {
       if (nextProps.redraw) {
         chart.destroy();
         this.initializeChart(nextProps);
-      } else if (nextProps.stream) {
+      } else if (nextProps.stream && nextProps.data.nextPoints) {
         chart.addData(nextProps.data.nextPoints.values, nextProps.data.nextPoints.label);
         chart.removeData();
       } else {

--- a/lib/core.js
+++ b/lib/core.js
@@ -3,7 +3,7 @@ var ReactDOM = require('react-dom');
 
 module.exports = {
   createClass: function(chartType, methodNames, dataKey) {
-    var excludedProps = ['data', 'options', 'redraw'];
+    var excludedProps = ['data', 'options', 'redraw', 'nextPoints', 'stream'];
     var classData = {
       displayName: chartType + 'Chart',
       getInitialState: function() { return {}; },
@@ -43,6 +43,9 @@ module.exports = {
       if (nextProps.redraw) {
         chart.destroy();
         this.initializeChart(nextProps);
+      } else if (nextProps.stream) {
+        chart.addData(nextProps.nextPoints.values, nextProps.nextPoints.label);
+        chart.removeData();
       } else {
         dataKey = dataKey || dataKeys[chart.name];
         updatePoints(nextProps, chart, dataKey);


### PR DESCRIPTION
Hi there,

I'm working on a dashboard project and find that react-chartjs does not support stream chart which chart.js does by addData() and removeData(). So I just added couple lines into react-chartjs core.js to support this feature. I've tested changes on dev environment and it just works.

The component jsx looks like this:
`<LineChart data={this.state.chartData} options={this.state.chartOptions} width={500} height={200} stream />`

The nextPoints is a json object under chartData with values and label like this (2-lines in example):
`
chartData: {
   labels: [...],
   datasets: [{
     ...
   }, {
     ...
   }],
   nextPoints: {
     values:  [<val1>, <val2>], 
     label: <newLabel>
   }
}`

I really appreciate it if you can take a quick review.

Thanks,
Kevin 