### PR TITLE
Fix issue when componentWillUnmount()

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -35,7 +35,8 @@ module.exports = {
 
     classData.componentWillUnmount = function() {
       var chart = this.state.chart;
-      chart.destroy();
+      if(chart)
+        chart.destroy();
     };
 
     classData.componentWillReceiveProps = function(nextProps) {


### PR DESCRIPTION
When componentWillUnmount, it tries to get chart object from this.state and execute destroy() function. This is not validating when chart is undefined or null.
This PR, **only** verifies that condition.