### PR TITLE
Fix: Export horizontal bar chart

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ module.exports = {
   Bar: require('./lib/bar'),
   Bubble: require('./lib/bubble'),
   Doughnut: require('./lib/doughnut'),
+  HorizontalBar: require('./lib/horizontal-bar'),
   Line: require('./lib/line'),
   Pie: require('./lib/pie'),
   PolarArea: require('./lib/polar-area'),


### PR DESCRIPTION
Export `HorizontalBar` for access via ES6 syntax, i.e.

```javascript
import { HorizontalBar as HorizontalBarChart } from 'react-chartjs';
```