### PR TITLE
Check for options change in ComponentWillReceiveProps

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -48,9 +48,10 @@ module.exports = {
 
     classData.componentWillReceiveProps = function(nextProps) {
       var chart = this.state.chart;
+      var optsChange = JSON.stringify(nextProps.options) !== JSON.stringify(this.props.options);
 
-      if (nextProps.redraw) {
-        chart.destroy();	// Reset the array of datasets
+      if (nextProps.redraw || optsChange) {
+        chart.destroy();  // Reset the array of datasets
         this.initializeChart(nextProps);
       } else {
         // assign all of the properites from the next datasets to the current chart


### PR DESCRIPTION
Currently, `options` won't update along with the chart if new props are passed. This is especially an issue when updating charts dynamically (e.g. changing the `yAxes` label from a dropdown menu). There may be a slightly more elegant way to check for changes in user-defined options, but this check should not negatively affect performance.