### PR TITLE
Don't pass the redraw prop to canvas

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -20,7 +20,7 @@ module.exports = {
         };
         for (var name in this.props) {
           if (this.props.hasOwnProperty(name)) {
-            if (name !== 'data' && name !== 'options') {
+            if (name !== 'data' && name !== 'options' && name !== 'redraw') {
               _props[name] = this.props[name];
             }
           }


### PR DESCRIPTION
It's not a valid prop for canvas and creates a runtime warning in React.